### PR TITLE
Change two links in README.me to raw file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/SpywareFilte
 
 https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/SpywareFilter/sections/tracking_servers_firstparty.txt
 
-https://github.com/AdguardTeam/AdguardFilters/blob/master/MobileFilter/sections/spyware.txt
+https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/MobileFilter/sections/spyware.txt
 
-https://github.com/AdguardTeam/AdguardFilters/blob/master/MobileFilter/sections/adservers.txt
+https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/MobileFilter/sections/adservers.txt


### PR DESCRIPTION
Sorry for the small pull request! This way it's easier to directly copy the URLs into AdGuard (or other apps).